### PR TITLE
Add `--relational` to findscu call

### DIFF
--- a/autobidsportal/dcm4cheutils.py
+++ b/autobidsportal/dcm4cheutils.py
@@ -295,6 +295,7 @@ class Dcm4cheUtils:
             f"{self.connect}",
             "--accept-timeout",
             "10000",
+            "--relational",
             "--user",
             f"{pipes.quote(self.username)}",
             "--user-pass",


### PR DESCRIPTION
This gets around the issue of missing XML attributes due to recent changes + potential bug in previous version.

Should look into two stage querying - first the STUDY level and then the SERIES level.

See thread [here](https://github.com/khanlab/cfmm2tar/issues/12) about this issue.